### PR TITLE
Make subtitles clickable anchors

### DIFF
--- a/_layouts/homes.html
+++ b/_layouts/homes.html
@@ -74,8 +74,10 @@
                 <div class="tab-block active" id="tab1">
                   <div class="tab-body">
                     <div>
-                      <div class="tab-body-h">
-                        Introduce Asterinas
+                      <div class="subtitle">
+                        <a class="subtitle-text" id="introduce-asterinas" href="#introduce-asterinas">
+                          Introduce Asterinas
+                        </a>
                       </div>
                       <p class="tb-text">
                         Asterinas is a Rust OS kernel designed to offer the following distinctive features:
@@ -150,8 +152,10 @@
                 <div class="tab-block" id="tab2">
                   <div class="tab-body">
                     <div>
-                      <div class="tab-body-h">
-                        Introduce OSDK
+                      <div class="subtitle">
+                        <a class="subtitle-text" id="introduce-osdk" href="#introduce-osdk">
+                          Introduce OSDK
+                        </a>
                       </div>
                       <p class="tb-text">
                         Asterinas Operating System Development Kit (OSDK) helps OS devs to create, build, run, and test
@@ -457,8 +461,10 @@
                 <!-- <span></span> -->
                 <div>
                   <div>
-                    <div class="tab-body-hTwo">
-                      Why a framekernel?
+                    <div class="subtitle">
+                      <a class="subtitle-text" id="framekernel" href="#framekernel">
+                        Why a framekernel?
+                      </a>
                     </div>
                     <div class="speed">
 
@@ -566,8 +572,10 @@
                     </div>
                   </div>
                   <div>
-                    <div class="tab-body-hTwo" style="width: 11.25rem;">
-                      Get involved
+                    <div class="subtitle">
+                      <a class="subtitle-text" id="get-involved" href="#get-involved">
+                        Get involved
+                      </a>
                     </div>
                     <div class="tb-text">
                       We are committed to creating a fully-fledged, production-grade OS kernel, and we recognize
@@ -624,8 +632,10 @@
                     </div>
                   </div>
                   <div>
-                    <div class="tab-body-hTwo" style="width: 9.4rem;">
-                      Thank you
+                    <div class="subtitle">
+                      <a class="subtitle-text" id="thank-you" href="#thank-you">
+                        Thank you
+                      </a>
                     </div>
                     <div class="tb-text">
                       We express our heartfelt gratitude to the contributors who have made this project a reality.

--- a/css/style-mobile.css
+++ b/css/style-mobile.css
@@ -358,16 +358,17 @@ a {
     display: block;
 }
 
-
-/* 字体 */
-.tab-body-h {
-    width: 17.65rem;
-    margin-left: 1.5rem;
+/* subtitle */
+.subtitle {
+    margin-top: 1.8rem;
+    margin-bottom: 0.8rem;
+    padding: 0 1.5rem;
+}
+.subtitle-text {
     font-size: 1.9rem;
     background: linear-gradient(to right, #1937FF, #00F7FF);
     background-clip: text;
     color: transparent;
-    margin-bottom: 2rem;
 }
 
 .tb-text {
@@ -429,17 +430,6 @@ a {
 .tb-feature-text {
     font-size: 1.4rem;
     color: #7F818C;
-}
-
-.tab-body-hTwo {
-    width: 18.1rem;
-    margin-left: 1.5rem;
-    font-size: 1.9rem;
-    background: linear-gradient(to right, #1937FF, #00F7FF);
-    background-clip: text;
-    color: transparent;
-    margin-bottom: 2rem;
-    margin-top: 6rem;
 }
 
 .speed {

--- a/css/style.css
+++ b/css/style.css
@@ -382,17 +382,19 @@
  .tabs .tab-bodies .active {
      display: block;
  }
- 
- /* 字体 */
- .tab-body-h {
-     width: 5rem;
+
+/* subtitle */
+.subtitle {
+    margin-top: 0.8rem;
+    margin-bottom: 0.3rem;
+}
+.subtitle-text {
      font-size: .48rem;
      background: linear-gradient(to right, #1937FF, #00F7FF);
      background-clip: text;
      color: transparent;
-     margin-bottom: .5rem;
  }
- 
+
  .tb-text {
      width: 12rem;
      font-size: .24rem;
@@ -532,16 +534,6 @@
      color: #7F818C;
      margin-left: -1.5rem;
      text-align: center;
- }
- 
- .tab-body-hTwo {
-     width: 5rem;
-     font-size: .48rem;
-     background: linear-gradient(to right, #1937FF, #00F7FF);
-     background-clip: text;
-     color: transparent;
-     margin-bottom: .5rem;
-     margin-top: 2.5rem;
  }
  
  .speed {


### PR DESCRIPTION
Subtitles are made to anchor via `id` and `href` props. Title click will update the link address bar.

<img width="2808" height="435" alt="image" src="https://github.com/user-attachments/assets/a5c4d178-81be-4282-8867-e505236b062f" />

---

Also fixed the text background-clip by wrapping  `<a>`  in `<div>` and cleaning up `tab-body-h`.

<details><summary>Styling before the PR: wide top margin, and  linear-gradient not working due to the fixed width</summary>
<p>

<img width="3006" height="1311" alt="image" src="https://github.com/user-attachments/assets/bbc06c05-57fb-473c-ace8-2c13e4ddfa26" />

</p>
</details> 


<details><summary>Styling after the PR: top margin is not too wide, and linear-gradient just works with no explicit width</summary>
<p>

<img width="3046" height="1069" alt="image" src="https://github.com/user-attachments/assets/41213d9c-376e-40c1-90a1-06e2d68e1d6a" />

</p>
</details> 

Preview: https://asterinas-github-io-git-subtitle-522241-zjps-projects-41f7e8dc.vercel.app